### PR TITLE
Pandoc maximum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Current build status
 
 <table><tr><td>All platforms:</td>
     <td>
-      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6072&branchName=master">
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=&branchName=master">
         <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/panflute-feedstock?branchName=master">
       </a>
     </td>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,9 @@
 {% set name = "panflute" %}
 {% set version = "2.0.5" %}
+# inclusive
 {% set pandoc_minimum_version = "2.11.0.4" %}
+# exclusive
+{% set pandoc_maximum_version = "2.12" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +15,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   entry_points:
     - panflute = panflute:main
     - panfl = panflute:panfl
@@ -27,7 +30,7 @@ requirements:
     - pyyaml
     - click
   run_constrained:
-    - pandoc >={{ pandoc_minimum_version }}
+    - pandoc >={{ pandoc_minimum_version }},<{{ pandoc_maximum_version }}
 
 test:
   imports:
@@ -39,7 +42,7 @@ test:
     - panfl --help
   requires:
     - pip
-    - pandoc >={{ pandoc_minimum_version }}
+    - pandoc >={{ pandoc_minimum_version }},<{{ pandoc_maximum_version }}
 
 about:
   home: https://github.com/sergiocorreia/panflute


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

We better protect against future compatibility issues. Since pandoc follows [Haskell's PVP MAJOR.MAJOR.MINOR.PATCH](https://pvp.haskell.org/) versioning scheme, I constrain it to be <2.12, the next major upgrade that could have incompatible API.

This PR just added a pandoc_maximum_version to protect against that. I'd rather be safe than sorry, and when I test that the new version coming out working with ours I'll bump it again.